### PR TITLE
修复几个报错

### DIFF
--- a/Modules/Chat/EnhancedFriendList.lua
+++ b/Modules/Chat/EnhancedFriendList.lua
@@ -178,7 +178,7 @@ function EFL:UpdateFriendButton(button)
         if game == BNET_CLIENT_WOW then
             name = gameAccountInfo.characterName or ""
             level = gameAccountInfo.characterLevel or 0
-            faction = gameAccountInfo.factionName or ""
+            faction = gameAccountInfo.factionName or nil
             class = gameAccountInfo.className or ""
             area = gameAccountInfo.areaName or ""
 

--- a/core.lua
+++ b/core.lua
@@ -43,6 +43,7 @@ end
 
 -- 为字符串添加自定义颜色(适合数据库形式的上色)
 function WT:ColorStrWithPack(str, colorPack)
+	if not colorPack then return str end
 	local r, g, b = colorPack.r, colorPack.g, colorPack.b
 	if not r or not g or not b then return str end
 	return WT:ColorStr(str, r, g, b)


### PR DESCRIPTION
core.lua
WT:ColorStrWithPack(str, colorPack)
colorPack有时传递nil导致报错，添加前置if检验nil

EnhancedFriendList.lua
有罕见的无法获取阵营的情况（出现在怀旧服），此时字符串""不代表nil，导致232行button.gameIcon:SetTexture(GameIcons[faction or game][self.db.textures.game])的GameIcons[faction or game]判断为GameIcons[""]出现报错