### PR TITLE
修复自动交还任务时报错的问题

### DIFF
--- a/Modules/Quest/TurnIn.lua
+++ b/Modules/Quest/TurnIn.lua
@@ -409,7 +409,7 @@ end
 
 function TI:QUEST_ITEM_UPDATE()
     if choiceQueue and self[choiceQueue] then
-        self[choiceQueue]()
+        self[choiceQueue](self)
     end
 end
 


### PR DESCRIPTION
Message: ...face\AddOns\ElvUI_WindTools\Modules\Quest\TurnIn.lua:455: attempt to index local 'self' (a nil value)
Time: Fri Nov 27 23:18:46 2020
Count: 6
Stack: ...face\AddOns\ElvUI_WindTools\Modules\Quest\TurnIn.lua:455: attempt to index local 'self' (a nil value)
[string "=(tail call)"]: ?
[string "@Interface\AddOns\ElvUI_WindTools\Modules\Quest\TurnIn.lua"]:455: in function `?'
[string "@Interface\AddOns\ElvUI_WindTools\Modules\Quest\TurnIn.lua"]:412: in function `?'
[string "@Interface\AddOns\BigWigs\Libs\CallbackHandler-1.0\CallbackHandler-1.0.lua"]:119: in function <...igs\Libs\CallbackHandler-1.0\CallbackHandler-1.0.lua:119>
[string "=[C]"]: ?
[string "@Interface\AddOns\BigWigs\Libs\CallbackHandler-1.0\CallbackHandler-1.0.lua"]:29: in function <...igs\Libs\CallbackHandler-1.0\CallbackHandler-1.0.lua:25>
[string "@Interface\AddOns\BigWigs\Libs\CallbackHandler-1.0\CallbackHandler-1.0.lua"]:64: in function `Fire'
[string "@Interface\AddOns\ElvUI\Libraries\Ace3\AceEvent-3.0\AceEvent-3.0.lua"]:120: in function <...s\ElvUI\Libraries\Ace3\AceEvent-3.0\AceEvent-3.0.lua:119>

Locals: <none>