### PR TITLE
Added autojoin, added filters safe mode

### DIFF
--- a/Modules/Misc/LFGList.lua
+++ b/Modules/Misc/LFGList.lua
@@ -615,6 +615,27 @@ function LL:InitalizeRightPanel()
         end
     )
 
+    hooksecurefunc("LFGListSearchEntry_OnClick", function (s, button)
+        if not self.db.rightPanel.autoJoin then return end
+    
+        local panel = LFGListFrame.SearchPanel
+        if button ~= "RightButton" and LFGListSearchPanelUtil_CanSelectResult(s.resultID) and panel.SignUpButton:IsEnabled() then
+            if panel.selectedResult ~= s.resultID then
+                LFGListSearchPanel_SelectResult(panel, s.resultID)
+            end
+            LFGListSearchPanel_SignUp(panel)
+        end
+    end)
+    
+    LFGListApplicationDialog:HookScript("OnShow", function(s)
+        if not self.db.rightPanel.skipConfirmation then return end
+    
+        if s.SignUpButton:IsEnabled() and not IsShiftKeyDown() then
+            s.SignUpButton:Click()
+        end
+    end)
+
+
     local currAffixIndex = 0
     local currAffixes = C_MythicPlus_GetCurrentAffixes()
 
@@ -999,7 +1020,7 @@ function LL:InitalizeRightPanel()
             if button == "LeftButton" then
                 local dfDB = self:GetPlayerDB("dungeonFilter")
                 btn:SetActive(not btn.active)
-                if btn.active then
+                if btn.active and not self.db.rightPanel.disableSafeFilters then
                     needTank:SetActive(false)
                     needHealer:SetActive(false)
                     dfDB.needTankEnable = false
@@ -1051,7 +1072,7 @@ function LL:InitalizeRightPanel()
             if button == "LeftButton" then
                 local dfDB = self:GetPlayerDB("dungeonFilter")
                 btn:SetActive(not btn.active)
-                if btn.active then
+                if btn.active and not self.db.rightPanel.disableSafeFilters then
                     roleAvailable:SetActive(false)
                     dfDB.roleAvailableEnable = false
                 end
@@ -1100,7 +1121,7 @@ function LL:InitalizeRightPanel()
             if button == "LeftButton" then
                 local dfDB = self:GetPlayerDB("dungeonFilter")
                 btn:SetActive(not btn.active)
-                if btn.active then
+                if btn.active and not self.db.rightPanel.disableSafeFilters then
                     roleAvailable:SetActive(false)
                     dfDB.roleAvailableEnable = false
                 end
@@ -1491,6 +1512,9 @@ function LL:UpdateRightPanel()
 
     self.rightPanel.sortPanel.sortByButton:SetActive(false)
     self.rightPanel.sortPanel.sortByButton.UpdatePosition()
+
+
+
 
     self.rightPanel:Show()
 end

--- a/Options/Misc.lua
+++ b/Options/Misc.lua
@@ -1862,6 +1862,52 @@ options.lfgList = {
                     type = "toggle",
                     name = L["Auto Refresh"],
                     desc = L["Automatically refresh the list after you changing the filter."]
+                },
+                automations = {
+                    order = 3,
+                    type = "group",
+                    inline = true,
+                    name = L["Automation"],
+                    args = {
+                        autoJoin = {
+                            order = 3,
+                            type = "toggle",
+                            name = L["Auto Join"],
+                            desc = L["Automatically join the dungeon when clicking on the LFG row, without asking for role confirmation."]
+                        },
+                        skipConfirmation = {
+                            order = 4,
+                            type = "toggle",
+                            name = L["Skip Confirmation"],
+                            desc = L["Skip signup confirmation during automatic join on listing click"]
+                        }
+                    }
+                },
+                filtersBehaviour = {
+                    order = 4,
+                    type = "group",
+                    inline = true,
+                    name = L["Filters"],
+                    args = {
+                        feature = {
+                            order = 1,
+                            type = "description",
+                            name = format(
+                                "%s\n|cffff0000%s|r\n\n%s\n%s",
+                                L["Automatic filters behaviour"],
+                                L["!! - WARNING: Change this only if you know what you are doing - !!"],
+                                L["- |cff00aaffUnchecked|r: When selecting 'Has Tank' / 'Has Healer', the 'Role Available' filter is disabled automatically and vice-versa"],
+                                L["- |cff00aaffChecked|r: No automatic removal of filters, might cause empty results if you already have the roles in your party"]
+                            ),
+                            fontSize = "medium"
+                        },
+                        disableSafeFilters = {
+                            order = 2,
+                            type = "toggle",
+                            name = L["Disable safe filters"],
+                            desc = L["Disable the default behaviour that prevents inconsistent filters with flags 'Has Tank', 'Has Healer' and 'Role Available'"]
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Hey! New changes on the LFG Panel

1. Added autojoin - Skip confirm options (Default disabled) to reduce number of clicks to join a pug
2. Added options to disable the safe mode for role filters
> - By default the filters mantain the current behaviour (Can't set both has tank / healer and "Role Available"
> - Added options to disable the automatic change and leave control to the player

![image](https://github.com/fang2hou/ElvUI_WindTools/assets/62181292/7d864b77-fff0-4ff5-b0f2-a995ef6bea31)
