### PR TITLE
LFG List - Fix filters update

### DIFF
--- a/Modules/Misc/LFGList.lua
+++ b/Modules/Misc/LFGList.lua
@@ -1588,7 +1588,6 @@ function LL:UpdateAdvancedFilters()
     advFilters.hasTank = dfDB.needTankEnable
     advFilters.hasHealer = dfDB.needHealerEnable
     advFilters.minimumRating = dfDB.leaderScoreEnable and dfDB.leaderScore or 0
-    _G.MinRatingFrame.MinRating:SetNumber(advFilters.minimumRating)
 
     local activities = {}
     local numActiveMaps = 0


### PR DESCRIPTION
Previously was manually updating builtin LFG Filter min rating field.
Now this is no longer needed, as the field is automatically updated from the filter object change.

As per my test the module does not present any additional error, let me know if you find something